### PR TITLE
docs(features): add link to sift documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Heavily inspired by [cancan](https://github.com/CanCanCommunity/cancancan).
 
 ## Features
 
-* supports MongoDB like conditions (`$eq`, `$ne`, `$in`, `$all`, `$gt`, `$lt`, `$gte`, `$lte`, `$exists`, `$regex`, field dot notation)
+* supports [sift.js](https://github.com/crcn/sift.js/tree/7.0.1) MongoDB like conditions (`$eq`, `$ne`, `$in`, `$all`, `$gt`, `$lt`, `$gte`, `$lte`, `$exists`, `$regex`, field dot notation)
 * supports direct and inverted rules (i.e., `can` & `cannot`)
 * provides ES6 build, so you are able to shake out unused functionality
 * provides easy integration with [popular frontend frameworks](#4-ui-integration)


### PR DESCRIPTION
Hey!

I spent a bunch of time trying to add a complex Regex condition because I couldn't find any operator helping in my use case to find out casl is using sift.js which supports $nin (It works).

Related PR [PR-188](https://github.com/stalniy/casl/pull/188)